### PR TITLE
link to bugs-site from gitlab to github

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@
     <author mail="contact@jeppezapp.com" >Jeppe Zapp</author>
     <namespace>Cookbook</namespace>
     <category>organization</category>
-    <bugs>https://gitlab.com/mrzapp/nextcloud-cookbook/issues</bugs>
+    <bugs>https://github.com/mrzapp/nextcloud-cookbook/issues</bugs>
     <dependencies>
         <nextcloud min-version="14" max-version="17"/>
     </dependencies>


### PR DESCRIPTION
https://apps.nextcloud.com/apps/cookbook buttons for issues & features link to the old gitlab-repo (which doesn't exist anymore because 404 is given)
I hope this updates those links.