### PR TITLE
Added support for translations

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1,6 +1,8 @@
 (function (OC, window, $, undefined) {
 'use strict';
 
+var appName = 'cookbook';
+
 $(document).ready(function () {
 
 /**
@@ -88,7 +90,7 @@ Cookbook.prototype = {
         var self = this;
 
         OC.dialogs.filepicker(
-            'Path to your recipe collection',
+            t(appName, 'Path to your recipe collection'),
             function (path) {
                 $.ajax({
                     url: self._baseUrl + '/config',
@@ -103,7 +105,7 @@ Cookbook.prototype = {
                         cb(path);
                     });
                 }).fail(function () {
-                    alert('Could not set recipe folder to ' + path);
+                    alert(t(appName, 'Could not set recipe folder to {path}', {path: path}));
                     cb(null);
                 });
             },
@@ -128,7 +130,7 @@ var Content = function (cookbook) {
         var isEditor = location.hash.indexOf('|edit') > -1 || location.hash === '#new';
 
         if(!recipeId && !isEditor) {
-            $('#app-content-wrapper').html('Please pick a recipe');
+            $('#app-content-wrapper').html(t(appName, 'Please pick a recipe'));
         } else {
             $.ajax({
                 url: cookbook._baseUrl + '/' + (isEditor ? 'edit' : 'recipe') + (isEditor && !recipeId ? '?new' : '?id=' + recipeId),
@@ -149,7 +151,7 @@ var Content = function (cookbook) {
                 self.updateListItems();
             })
             .fail(function (e) {
-                alert('Could not load recipe');
+                alert(t(appName, 'Could not load recipe'));
 
                 if(e && e instanceof Error) { throw e; }
             });
@@ -229,7 +231,7 @@ var Content = function (cookbook) {
             nav.render();
         })
         .fail(function(e) {
-            alert('Could not update recipe');
+            alert(t(appName, 'Could not update recipe'));
             
             if(e && e instanceof Error) { throw e; }
         });
@@ -275,7 +277,7 @@ var Nav = function (cookbook) {
             self.render();
         })
         .fail(function () {
-            alert('Could not add recipe');
+            alert(t(appName, 'Could not add recipe'));
         });
     };
 
@@ -297,7 +299,7 @@ var Nav = function (cookbook) {
             self.render();
         })
         .fail(function (e) {
-            alert('Could not rebuild recipe index.');
+            alert(t(appName, 'Could not rebuild recipe index.'));
         });
     };
 
@@ -312,7 +314,7 @@ var Nav = function (cookbook) {
      * Event: Delete recipe
      */
     self.onDeleteRecipe = function(e) {
-        if(!confirm('Are you sure you want to delete this recipe?')) { return; }
+        if(!confirm(t(appName, 'Are you sure you want to delete this recipe?'))) { return; }
 
         var id = e.currentTarget.dataset.id;
         
@@ -328,7 +330,7 @@ var Nav = function (cookbook) {
             self.render();
         })
         .fail(function(e) {
-            alert('Failed to delete recipe');
+            alert(t(appName, 'Failed to delete recipe'));
 
             if(e && e instanceof Error) { throw e; }
         });
@@ -359,7 +361,7 @@ var Nav = function (cookbook) {
             $('#app-navigation #recipes .button-delete button').click(self.onDeleteRecipe);
         })
         .fail(function(e) {
-            alert('Failed to fetch recipes');
+            alert(t(appName, 'Failed to fetch recipes'));
 
             if(e && e instanceof Error) { throw e; }
         });

--- a/templates/content/edit.php
+++ b/templates/content/edit.php
@@ -1,43 +1,43 @@
 <form action="/index.php/apps/cookbook/update" method="POST">
     <fieldset>
-        <label>Name</label>
+        <label><?php /* TRANSLATORS The name of the recipe */echo p($l->t('Name')); ?></label>
         <input required type="text" name="name" value="<?php echo $_['name']; ?>"></h2>
     </fieldset>
 
     <fieldset>
-        <label>Image URL</label>
+        <label><?php p($l->t('Image URL')); ?></label>
         <input type="text" name="image" value="<?php echo $_['image']; ?>">
     </fieldset>
     
     <fieldset>
-        <label>Keywords (comma-separated)</label>
+        <label><?php p($l->t('Keywords (comma-separated)')); ?></label>
         <input type="text" name="keywords" value="<?php echo $_['keywords']; ?>">
     </fieldset>
 
     <fieldset>
-        <label>Servings</label>
+        <label><?php p($l->t('Servings')); ?></label>
         <input type="number" name="recipeYield" value="<?php echo $_['recipeYield']; ?>">
     </fieldset>
     
     <?php 
 
     $daily_dozen = [
-        'beansAndLegumes' => [ 'icon' => '🥛', 'name' => 'Beans and legumes' ],
-        'berries' => [ 'icon' => '🍓', 'name' => 'Berries' ],
-        'cruciferousVegetables' => [ 'icon' => '🥦', 'name' => 'Cruciferous vegetables' ],
-        'flaxseeds' => [ 'icon' => '🌱', 'name' => 'Flaxseeds' ],
-        'greens' => [ 'icon' => '🥬', 'name' => 'Greens' ],
-        'nutsAndSeeds' => [ 'icon' => '🌰', 'name' => 'Nuts and seeds' ],
-        'otherFruits' => [ 'icon' => '🍌', 'name' => 'Other fruits' ],
-        'otherVegetables' => [ 'icon' => '🥑', 'name' => 'Other vegetables' ],
-        'herbsAndSpices' => [ 'icon' => '🌿', 'name' => 'Herbs and spices' ],
-        'wholeGrains' => [ 'icon' => '🍞', 'name' => 'Whole grains' ],
+        'beansAndLegumes' => [ 'icon' => '🥛', 'name' => $l->t('Beans and legumes') ],
+        'berries' => [ 'icon' => '🍓', 'name' => $l->t('Berries') ],
+        'cruciferousVegetables' => [ 'icon' => '🥦', 'name' => $l->t('Cruciferous vegetables') ],
+        'flaxseeds' => [ 'icon' => '🌱', 'name' => $l->t('Flaxseeds') ],
+        'greens' => [ 'icon' => '🥬', 'name' => $l->t('Greens') ],
+        'nutsAndSeeds' => [ 'icon' => '🌰', 'name' => $l->t('Nuts and seeds') ],
+        'otherFruits' => [ 'icon' => '🍌', 'name' => $l->t('Other fruits') ],
+        'otherVegetables' => [ 'icon' => '🥑', 'name' => $l->t('Other vegetables') ],
+        'herbsAndSpices' => [ 'icon' => '🌿', 'name' => $l->t('Herbs and spices') ],
+        'wholeGrains' => [ 'icon' => '🍞', 'name' => $l->t('Whole grains') ],
     ];
 
     ?>
 
     <fieldset>
-        <label>Daily dozen</label>
+        <label><?php p($l->t('Daily dozen')); ?></label>
 
         <ul>
             <?php foreach($daily_dozen as $id => $ingredient) { ?>
@@ -54,7 +54,7 @@
     </fieldset>
 
     <fieldset>
-        <label>Ingredients</label>
+        <label><?php p($l->t('Ingredients')); ?></label>
 
         <ul>
             <template>
@@ -74,7 +74,7 @@
     </fieldset>
 
     <fieldset>
-        <label>Instructions</label>
+        <label><?php p($l->t('Instructions')); ?></label>
 
         <ul>
             <template>
@@ -93,5 +93,5 @@
         </ul>
     </fieldset>
 
-    <button type="submit">Save</button>
+    <button type="submit"><?php p($l->t('Save')); ?></button>
 </form>

--- a/templates/content/recipe.php
+++ b/templates/content/recipe.php
@@ -8,21 +8,22 @@
     <h2><?php echo $_['name']; ?></h2>
     
     <p><?php echo $_['recipeYield']; ?> serving<?php if($_['recipeYield'] > 1) { echo 's'; } ?></p>
+    <p><?php p($l->n('One serving', '%n servings', $_['recipeYield'])); ?></p>
     
     <?php if(isset($_['dailyDozen'])) { ?>
         <?php 
 
         $daily_dozen = [
-            'beansAndLegumes' => [ 'icon' => '🥛', 'name' => 'Beans and legumes' ],
-            'berries' => [ 'icon' => '🍓', 'name' => 'Berries' ],
-            'cruciferousVegetables' => [ 'icon' => '🥦', 'name' => 'Cruciferous vegetables' ],
-            'flaxseeds' => [ 'icon' => '🌱', 'name' => 'Flaxseeds' ],
-            'greens' => [ 'icon' => '🥬', 'name' => 'Greens' ],
-            'nutsAndSeeds' => [ 'icon' => '🌰', 'name' => 'Nuts and seeds' ],
-            'otherFruits' => [ 'icon' => '🍌', 'name' => 'Other fruits' ],
-            'otherVegetables' => [ 'icon' => '🥑', 'name' => 'Other vegetables' ],
-            'herbsAndSpices' => [ 'icon' => '🌿', 'name' => 'Herbs and spices' ],
-            'wholeGrains' => [ 'icon' => '🍞', 'name' => 'Whole grains' ],
+            'beansAndLegumes' => [ 'icon' => '🥛', 'name' => $l->t('Beans and legumes') ],
+            'berries' => [ 'icon' => '🍓', 'name' => $l->t('Berries') ],
+            'cruciferousVegetables' => [ 'icon' => '🥦', 'name' => $l->t('Cruciferous vegetables') ],
+            'flaxseeds' => [ 'icon' => '🌱', 'name' => $l->t('Flaxseeds') ],
+            'greens' => [ 'icon' => '🥬', 'name' => $l->t('Greens') ],
+            'nutsAndSeeds' => [ 'icon' => '🌰', 'name' => $l->t('Nuts and seeds') ],
+            'otherFruits' => [ 'icon' => '🍌', 'name' => $l->t('Other fruits') ],
+            'otherVegetables' => [ 'icon' => '🥑', 'name' => $l->t('Other vegetables') ],
+            'herbsAndSpices' => [ 'icon' => '🌿', 'name' => $l->t('Herbs and spices') ],
+            'wholeGrains' => [ 'icon' => '🍞', 'name' => $l->t('Whole grains') ],
         ];
     
         ?>
@@ -37,7 +38,7 @@
 
 <aside>
     <ul>
-        <h3>Ingredients</h3>
+        <h3><?php p($l->t('Ingredients')); ?></h3>
 
         <?php foreach($_['recipeIngredient'] as $ingredient) {  ?>
             <li><?php echo $ingredient; ?></li>   
@@ -47,7 +48,7 @@
 
 <main>
     <ul>
-        <h3>Instructions</h3>
+        <h3><?php p($l->t('Instructions')); ?></h3>
 
         <?php foreach($_['recipeInstructions'] as $step) {  ?>
             <li><?php echo $step; ?></li>   

--- a/templates/navigation/index.php
+++ b/templates/navigation/index.php
@@ -1,17 +1,17 @@
 <form id="create-recipe" class="app-navigation-create">
-    <button type="submit" title="Create recipe" class="button icon-add">Create recipe</button>
+    <button type="submit" title="<?php p($l->t('Create recipe')); ?>" class="button icon-add"><?php p($l->t('Create recipe')); ?></button>
 </form>
 
 <form id="add-recipe" class="app-navigation-new">
-    <input name="url" placeholder="Recipe URL">
-    <button type="submit" title="Download recipe">
+    <input name="url" placeholder="<?php p($l->t('Recipe URL')); ?>">
+    <button type="submit" title="<?php p($l->t('Download recipe')); ?>">
         <div class="icon-download"></div>
         <div class="icon-loading float-spinner"></div>
     </button>
 </form>
 
 <form id="find-recipes" class="app-navigation-new">
-    <input list="list-keywords" name="keywords" placeholder="Search" multiple>
+    <input list="list-keywords" name="keywords" placeholder="<?php p($l->t('Search')); ?>" multiple>
     <datalist id="list-keywords">
         <?php foreach($_['all_keywords'] as $keyword) { ?>
             <option value="<?php echo $keyword['name']; ?>">

--- a/templates/navigation/recipes.php
+++ b/templates/navigation/recipes.php
@@ -7,10 +7,10 @@
         <div class="app-navigation-entry-utils">
             <ul>
                 <li class="app-navigation-entry-utils-menu-button button-edit">
-                    <button class="svg action icon-rename" data-id="<?php echo $recipe['recipe_id']; ?>" title="Edit recipe"></button>
+                    <button class="svg action icon-rename" data-id="<?php echo $recipe['recipe_id']; ?>" title="<?php p($l->t('Edit recipe')); ?>"></button>
                 </li>
                 <li class="app-navigation-entry-utils-menu-button button-delete">
-                    <button class="svg action icon-delete" data-id="<?php echo $recipe['recipe_id']; ?>" title="Delete recipe"></button>
+                    <button class="svg action icon-delete" data-id="<?php echo $recipe['recipe_id']; ?>" title="<?php p($l->t('Delete recipe')); ?>"></button>
                 </li>
             </ul>
         </div>

--- a/templates/settings/index.php
+++ b/templates/settings/index.php
@@ -1,16 +1,16 @@
 <div id="app-settings">
     <div id="app-settings-header">
-        <button class="settings-button" data-apps-slide-toggle="#app-settings-content">Settings</button>
+        <button class="settings-button" data-apps-slide-toggle="#app-settings-content"><?php p($l->t('Settings')); ?></button>
     </div>
     <div id="app-settings-content">
         <fieldset class="settings-fieldset">
             <ul class="settings-fieldset-interior">
                 <li class="settings-fieldset-interior-item">
-                    <button class="button icon-history" id="reindex-recipes">Rescan library</button>
+                    <button class="button icon-history" id="reindex-recipes"><?php p($l->t('Rescan library')); ?></button>
                 </li>
                 <li class="settings-fieldset-interior-item">
-                    <label class="settings-input">Recipe folder</label>
-                    <input id="recipe-folder" type="text" class="input settings-input" value="<?php echo $_['folder']; ?>" placeholder="Please pick a folder">
+                    <label class="settings-input"><?php p($l->t('Recipe folder')); ?></label>
+                    <input id="recipe-folder" type="text" class="input settings-input" value="<?php echo $_['folder']; ?>" placeholder="<?php p($l->t('Please pick a folder')); ?>">
                 </li>
             </ul>
         </fieldset>

--- a/translationfiles/de/cookbook.po
+++ b/translationfiles/de/cookbook.po
@@ -1,0 +1,214 @@
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the Nextcloud package.
+#
+# Christian Wolf <christian.wolf@aut.uni-saarland.de>, 2019.
+msgid ""
+msgstr ""
+"Project-Id-Version: Nextcloud 3.14159\n"
+"Report-Msgid-Bugs-To: translations\\@example.com\n"
+"POT-Creation-Date: 2019-08-08 14:07+0200\n"
+"PO-Revision-Date: 2019-08-08 14:38+0200\n"
+"Last-Translator: Christian Wolf <christian.wolf@aut.uni-saarland.de>\n"
+"Language-Team: German <kde-i18n-de@kde.org>\n"
+"Language: de_DE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 19.04.3\n"
+
+#: /srv/http/nc/apps/cookbook/js/script.js:91
+msgid "Path to your recipe collection"
+msgstr "Pfad zur Rezept-Datenbank"
+
+#: /srv/http/nc/apps/cookbook/js/script.js:106
+msgid "Could not set recipe folder to {path}"
+msgstr "Konnte den Pfad zu den Rezepten auf {path} setzen"
+
+#: /srv/http/nc/apps/cookbook/js/script.js:131
+msgid "Please pick a recipe"
+msgstr "Bitte ein Rezept auswählen"
+
+#: /srv/http/nc/apps/cookbook/js/script.js:152
+msgid "Could not load recipe"
+msgstr "Konnte Rezept nicht laden"
+
+#: /srv/http/nc/apps/cookbook/js/script.js:232
+msgid "Could not update recipe"
+msgstr "Konnte Rezept nicht aktualisieren"
+
+#: /srv/http/nc/apps/cookbook/js/script.js:278
+msgid "Could not add recipe"
+msgstr "Konnte Rezept nicht hinzufügen"
+
+#: /srv/http/nc/apps/cookbook/js/script.js:300
+msgid "Could not rebuild recipe index."
+msgstr "Konnte den Rezept-Index nicht neu aufbauen."
+
+#: /srv/http/nc/apps/cookbook/js/script.js:315
+msgid "Are you sure you want to delete this recipe?"
+msgstr "Soll das Rezept auch wirklich gelöscht werden?"
+
+#: /srv/http/nc/apps/cookbook/js/script.js:331
+msgid "Failed to delete recipe"
+msgstr "Löschen des Rezepts ist fehlgeschlagen"
+
+#: /srv/http/nc/apps/cookbook/js/script.js:362
+msgid "Failed to fetch recipes"
+msgstr "Laden des Rezepts ist fehlgeschlagen"
+
+#: /srv/http/nc/apps/cookbook/specialAppInfoFakeDummyForL10nScript.php:2
+msgid "Cookbook"
+msgstr "Kochbuch"
+
+#: /srv/http/nc/apps/cookbook/specialAppInfoFakeDummyForL10nScript.php:3
+msgid "An integrated cookbook using schema.org JSON files as recipes"
+msgstr ""
+"Ein integriertes Kochbuch, das schema.org JSON Dateien als Speicher für"
+" Rezepte nutzt"
+
+#: /srv/http/nc/apps/cookbook/specialAppInfoFakeDummyForL10nScript.php:4
+msgid ""
+"A library for all your recipes. It uses JSON files following the schema.org "
+"recipe format. To add a recipe to the collection, you can paste in the URL "
+"of the recipe, and the provided web page will be parsed and downloaded to "
+"whichever folder you specify in the app settings."
+msgstr ""
+"Eine Bibliothek aller Rezepte. Sie nutzt JSON Dateien, die dem schema.org"
+" Standard für Rezepte folgen. "
+"Um weitere Rezepte zu der Sammlung hinzuzufügen, kann die URL des Rezepts"
+" eingefügt werden, so dass die Seite heruntergeladen, analysiert und in einem"
+" benutzerspezifizierten Verzeichnis abgelegt wird."
+
+#. TRANSLATORS The name of the recipe
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:3
+msgid "Name"
+msgstr "Name"
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:8
+msgid "Image URL"
+msgstr "Bild-URL"
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:13
+msgid "Keywords (comma-separated)"
+msgstr "Schlagworte (mit Kommata abgetrennt)"
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:18
+msgid "Servings"
+msgstr "Portionen"
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:25
+#: /srv/http/nc/apps/cookbook/templates/content/recipe.php:17
+msgid "Beans and legumes"
+msgstr "Bohnen und Hülsenfrüchte"
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:26
+#: /srv/http/nc/apps/cookbook/templates/content/recipe.php:18
+msgid "Berries"
+msgstr "Beeren"
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:27
+#: /srv/http/nc/apps/cookbook/templates/content/recipe.php:19
+msgid "Cruciferous vegetables"
+msgstr "Kreuzblütler-Gemüse"
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:28
+#: /srv/http/nc/apps/cookbook/templates/content/recipe.php:20
+msgid "Flaxseeds"
+msgstr "Leinsamen"
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:29
+#, fuzzy
+#: /srv/http/nc/apps/cookbook/templates/content/recipe.php:21
+msgid "Greens"
+msgstr ""
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:30
+#: /srv/http/nc/apps/cookbook/templates/content/recipe.php:22
+msgid "Nuts and seeds"
+msgstr "Nüsse und Samen"
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:31
+#: /srv/http/nc/apps/cookbook/templates/content/recipe.php:23
+msgid "Other fruits"
+msgstr "Andere Früchte"
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:32
+#: /srv/http/nc/apps/cookbook/templates/content/recipe.php:24
+msgid "Other vegetables"
+msgstr "Andere Gemüsesorten"
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:33
+#: /srv/http/nc/apps/cookbook/templates/content/recipe.php:25
+msgid "Herbs and spices"
+msgstr "Kräuter und Gewürze"
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:34
+#: /srv/http/nc/apps/cookbook/templates/content/recipe.php:26
+msgid "Whole grains"
+msgstr "Vollkorn"
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:40
+#, fuzzy
+msgid "Daily dozen"
+msgstr ""
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:57
+#: /srv/http/nc/apps/cookbook/templates/content/recipe.php:41
+msgid "Ingredients"
+msgstr "Zutaten"
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:77
+#: /srv/http/nc/apps/cookbook/templates/content/recipe.php:51
+msgid "Instructions"
+msgstr "Anweisungen"
+
+#: /srv/http/nc/apps/cookbook/templates/content/edit.php:96
+msgid "Save"
+msgstr "Speichern"
+
+#: /srv/http/nc/apps/cookbook/templates/content/recipe.php:11
+msgid "One serving"
+msgid_plural "%n servings"
+msgstr[0] "Eine Portion"
+msgstr[1] "%n Portionen"
+
+#: /srv/http/nc/apps/cookbook/templates/navigation/index.php:2
+msgid "Create recipe"
+msgstr "Neues Rezept anlegen"
+
+#: /srv/http/nc/apps/cookbook/templates/navigation/index.php:6
+msgid "Recipe URL"
+msgstr "Rezept-URL"
+
+#: /srv/http/nc/apps/cookbook/templates/navigation/index.php:7
+msgid "Download recipe"
+msgstr "Rezept herunterladen"
+
+#: /srv/http/nc/apps/cookbook/templates/navigation/index.php:14
+msgid "Search"
+msgstr "Suche"
+
+#: /srv/http/nc/apps/cookbook/templates/navigation/recipes.php:10
+msgid "Edit recipe"
+msgstr "Rezept bearbeiten"
+
+#: /srv/http/nc/apps/cookbook/templates/navigation/recipes.php:13
+msgid "Delete recipe"
+msgstr "Rezept löschen"
+
+#: /srv/http/nc/apps/cookbook/templates/settings/index.php:3
+msgid "Settings"
+msgstr "Einstellungen"
+
+#: /srv/http/nc/apps/cookbook/templates/settings/index.php:9
+msgid "Rescan library"
+msgstr "Bibliothek neu einlesen"
+
+#: /srv/http/nc/apps/cookbook/templates/settings/index.php:12
+msgid "Recipe folder"
+msgstr "Rezept-Ordner"
+
+#: /srv/http/nc/apps/cookbook/templates/settings/index.php:13
+msgid "Please pick a folder"
+msgstr "Bitte einen Ordner auswählen"

--- a/translationfiles/de/cookbook.po
+++ b/translationfiles/de/cookbook.po
@@ -91,7 +91,7 @@ msgstr "Bild-URL"
 
 #: /srv/http/nc/apps/cookbook/templates/content/edit.php:13
 msgid "Keywords (comma-separated)"
-msgstr "Schlagworte (mit Kommata abgetrennt)"
+msgstr "Schlagworte (durch Kommas getrennt)"
 
 #: /srv/http/nc/apps/cookbook/templates/content/edit.php:18
 msgid "Servings"

--- a/translationfiles/de/cookbook.po
+++ b/translationfiles/de/cookbook.po
@@ -55,7 +55,7 @@ msgstr "Löschen des Rezepts ist fehlgeschlagen"
 
 #: /srv/http/nc/apps/cookbook/js/script.js:362
 msgid "Failed to fetch recipes"
-msgstr "Laden des Rezepts ist fehlgeschlagen"
+msgstr "Laden der Rezepte ist fehlgeschlagen"
 
 #: /srv/http/nc/apps/cookbook/specialAppInfoFakeDummyForL10nScript.php:2
 msgid "Cookbook"

--- a/translationfiles/de/cookbook.po
+++ b/translationfiles/de/cookbook.po
@@ -19,11 +19,11 @@ msgstr ""
 
 #: /srv/http/nc/apps/cookbook/js/script.js:91
 msgid "Path to your recipe collection"
-msgstr "Pfad zur Rezept-Datenbank"
+msgstr "Pfad zur Rezept-Sammlung"
 
 #: /srv/http/nc/apps/cookbook/js/script.js:106
 msgid "Could not set recipe folder to {path}"
-msgstr "Konnte den Pfad zu den Rezepten auf {path} setzen"
+msgstr "Konnte den Pfad '{path}' nicht als Rezept-Ordner setzen"
 
 #: /srv/http/nc/apps/cookbook/js/script.js:131
 msgid "Please pick a recipe"
@@ -47,7 +47,7 @@ msgstr "Konnte den Rezept-Index nicht neu aufbauen."
 
 #: /srv/http/nc/apps/cookbook/js/script.js:315
 msgid "Are you sure you want to delete this recipe?"
-msgstr "Soll das Rezept auch wirklich gelöscht werden?"
+msgstr "Soll das Rezept wirklich gelöscht werden?"
 
 #: /srv/http/nc/apps/cookbook/js/script.js:331
 msgid "Failed to delete recipe"
@@ -77,7 +77,7 @@ msgstr ""
 "Eine Bibliothek aller Rezepte. Sie nutzt JSON Dateien, die dem schema.org"
 " Standard für Rezepte folgen. "
 "Um weitere Rezepte zu der Sammlung hinzuzufügen, kann die URL des Rezepts"
-" eingefügt werden, so dass die Seite heruntergeladen, analysiert und in einem"
+" eingefügt werden, so dass die Seite heruntergeladen, verarbeitet und in einem"
 " benutzerspezifizierten Verzeichnis abgelegt wird."
 
 #. TRANSLATORS The name of the recipe
@@ -110,7 +110,7 @@ msgstr "Beeren"
 #: /srv/http/nc/apps/cookbook/templates/content/edit.php:27
 #: /srv/http/nc/apps/cookbook/templates/content/recipe.php:19
 msgid "Cruciferous vegetables"
-msgstr "Kreuzblütler-Gemüse"
+msgstr "Kreuzblütler-Gemüse (z.B. Kohl, Brokkoli oder Radieschen)"
 
 #: /srv/http/nc/apps/cookbook/templates/content/edit.php:28
 #: /srv/http/nc/apps/cookbook/templates/content/recipe.php:20
@@ -121,7 +121,7 @@ msgstr "Leinsamen"
 #, fuzzy
 #: /srv/http/nc/apps/cookbook/templates/content/recipe.php:21
 msgid "Greens"
-msgstr ""
+msgstr "Blattgemüse"
 
 #: /srv/http/nc/apps/cookbook/templates/content/edit.php:30
 #: /srv/http/nc/apps/cookbook/templates/content/recipe.php:22


### PR DESCRIPTION
Worked along https://docs.nextcloud.com/server/stable/developer_manual/app/view/l10n.html with manual process. If @mrzapp  wants to use transifexit might be better if you do it.

This is related to issue #21.

I did not write any documentation how to generate the translation files. Also I did not check in the generated pot and js files into git. You might want to define a best practice here.