### PR TITLE
Removing any reference to the master branch in documentations' links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ They probably haven't been indexed. Try clicking the Settings > Rescan library b
 A lot of websites are unfortunately not following the schema.org/Recipe standard, which makes their recipes impossible to read by this app.
 
 #### A website using correct schema.org markup is not being read correctly
-The parser is far from perfect. If you can help out in any way, please [have a look at the parseRecipeHtml() method](https://github.com/mrzapp/nextcloud-cookbook/blob/master/lib/Service/RecipeService.php) and create a pull request with your changes.
+The parser is far from perfect. If you can help out in any way, please [have a look at the parseRecipeHtml() method](https://github.com/mrzapp/nextcloud-cookbook/blob/develop/lib/Service/RecipeService.php) and create a pull request with your changes.
 
 #### All of the text is in English?
-If your language hasn't been added yet, your can help out by following [these](https://github.com/mrzapp/nextcloud-cookbook/tree/master/translationfiles) instructions
+If your language hasn't been added yet, your can help out by following [these](https://github.com/mrzapp/nextcloud-cookbook/tree/develop/translationfiles) instructions

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,7 +10,7 @@
     <author mail="mrzapp@users.noreply.github.com" >Jeppe Zapp</author>
     <namespace>Cookbook</namespace>
     <category>organization</category>
-    <screenshot small-thumbnail="https://raw.githubusercontent.com/mrzapp/nextcloud-cookbook/master/img/screenshot-small.jpg">https://raw.githubusercontent.com/mrzapp/nextcloud-cookbook/master/img/screenshot.jpg</screenshot>
+    <screenshot small-thumbnail="https://raw.githubusercontent.com/mrzapp/nextcloud-cookbook/stable/img/screenshot-small.jpg">https://raw.githubusercontent.com/mrzapp/nextcloud-cookbook/stable/img/screenshot.jpg</screenshot>
     <bugs>https://github.com/mrzapp/nextcloud-cookbook/issues</bugs>
     <dependencies>
         <nextcloud min-version="14" max-version="18"/>

--- a/translationfiles/README.md
+++ b/translationfiles/README.md
@@ -8,7 +8,7 @@ This is a quick instruction how to generate translations for the nextcoud app `c
 1. Clone a user fork of the [cookbook app](https://github.com/mrzapp/nextcloud-cookbook)
 2. Create new branch and checkout
 3. Use the `translationfiles/template/cookbook.pot` template and generate/update the `translationfiles/<lang>/cookbook.po` file
-4. Commit and create pull request
+4. Commit and create pull request against the `develop` branch
 
 ## Introduction
 
@@ -85,6 +85,7 @@ This will push the changed to your fork of the repo on github.
 To notify the developer of the changes, you need to open a pull request.
 To do so, git already outputs during the `git push` command execution an URL to help crating suh a pull request.
 Open the link in a browser and fill in the fields (sort of comments).
+Make sure you are using `base: develop` of `mrzapp/nextcloud-cookbook` repository in the dropdown list.
 The developer will either merge the chenages into the main development branch or come back to you with further questions.
 
 ## Steps to generate the necessary files in order to test the translation


### PR DESCRIPTION
Triggered by #75.

@mrzapp There is a change in `appinfo/info.xml` with a broken link to an old image URL. I do not know if this will break the presentation in the appstore....