### PR TITLE
German translation of "All"

### DIFF
--- a/translationfiles/de/cookbook.po
+++ b/translationfiles/de/cookbook.po
@@ -188,6 +188,10 @@ msgstr "Rezept herunterladen"
 msgid "Search"
 msgstr "Suche"
 
+#: /srv/http/nc/apps/cookbook/templates/navigation/index.php:28
+msgid "All"
+msgstr "Alle"
+
 #: /srv/http/nc/apps/cookbook/templates/navigation/recipes.php:10
 msgid "Edit recipe"
 msgstr "Rezept bearbeiten"

--- a/translationfiles/de_DE/cookbook.po
+++ b/translationfiles/de_DE/cookbook.po
@@ -187,6 +187,10 @@ msgstr "Rezept herunterladen"
 msgid "Search"
 msgstr "Suche"
 
+#: /srv/http/nc/apps/cookbook/templates/navigation/index.php:28
+msgid "All"
+msgstr "Alle"
+
 #: /srv/http/nc/apps/cookbook/templates/navigation/recipes.php:10
 msgid "Edit recipe"
 msgstr "Rezept bearbeiten"


### PR DESCRIPTION
The word "All" in the list of keywords / categories wasn't translated. I hope, this is the right way doing it.