### PR TITLE
Removed unused variables

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -37,12 +37,10 @@ class PageController extends Controller
     public function index()
     {
         $view_data = [
-            'all_recipes' => $this->service->getAllRecipesInSearchIndex(),
             'all_keywords' => $this->service->getAllKeywordsInSearchIndex(),
             'folder' => $this->service->getUserFolderPath(),
             'update_interval' => $this->service->getSearchIndexUpdateInterval(),
             'last_update' => $this->service->getSearchIndexLastUpdateTime(),
-            'current_node' => isset($_GET['recipe']) ? $this->service->getRecipeFileByFolderId($_GET['recipe']) : null
         ];
 
         return new TemplateResponse('cookbook', 'index', $view_data);  // templates/index.php


### PR DESCRIPTION
I searched the templates for any usage of the "all_recipes" or the
"current_node" variable and did find nothing. Deleting them has no
noticeable effect.
