### PR TITLE
Feature/enter opens image selection#108

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -198,7 +198,7 @@ var Content = function (cookbook) {
         e.preventDefault();
 
         OC.dialogs.filepicker(
-            t(appName, 'Path to your recipe collection'),
+            t(appName, 'Path to your Recipe Image'),
             function (path) {
                 $('input[name="image"]').val(path);
             },

--- a/templates/content/edit.php
+++ b/templates/content/edit.php
@@ -24,7 +24,7 @@
 
     <fieldset>
         <label><?php p($l->t('Image')); ?></label>
-        <input type="text" name="image" value="<?php if(isset($_['image'])) { echo $_['image']; } ?>"><button id="pick-image" title="<?php p($l->t('Pick a local image')) ?>"><span class="icon-category-multimedia"></span></button>
+        <input type="text" name="image" value="<?php if(isset($_['image'])) { echo $_['image']; } ?>"><button type="button" id="pick-image" title="<?php p($l->t('Pick a local image')) ?>"><span class="icon-category-multimedia"></span></button>
     </fieldset>
 
     <fieldset>


### PR DESCRIPTION
This should fix the bug mentioned in #108 

While [searching](https://stackoverflow.com/questions/23569073/button-onclick-fires-when-enter-key-is-pressed-in-input-text-field-in-ie) i found out that it is expected behavior that a button in a form catches all "enter" calls and interprets them as "clicks" except if the button is specifically defined as a button.

The Filepicker name for the Recipe Image was wrong and was therefore double confusing.