### PR TITLE
Hotfix/foreach#118

### DIFF
--- a/lib/Service/RecipeService.php
+++ b/lib/Service/RecipeService.php
@@ -231,6 +231,8 @@ class RecipeService
 
                 array_push($ingredients, $ingredient);
             }
+
+            $json['recipeIngredient'] = $ingredients;
         } else {
             $json['recipeIngredient'] = [];
         }

--- a/lib/Service/RecipeService.php
+++ b/lib/Service/RecipeService.php
@@ -198,6 +198,26 @@ class RecipeService
             $json['keywords'] = '';
         }
 
+        // Make sure that "tool" is an array of strings
+        if (isset($json['tool']) && is_array($json['tool'])) {
+            $tools = [];
+
+            foreach ($json['tool'] as $i => $tool) {
+                $tool = $this->cleanUpString($tool);
+
+                if (!$tool) {
+                    continue;
+                }
+
+                array_push($tools, $tool);
+            }
+            $json['tool'] = $tools;
+        } else {
+            $json['tool'] = [];
+        }
+
+        $json['tool'] = array_filter($json['tool']);
+
         // Make sure that "recipeIngredient" is an array of strings
         if (isset($json['recipeIngredient']) && is_array($json['recipeIngredient'])) {
             $ingredients = [];

--- a/templates/content/recipe.php
+++ b/templates/content/recipe.php
@@ -49,27 +49,27 @@
 <aside>
     <ul>
         <h3><?php p($l->t('Tools')); ?></h3>
-        <?php if(isset($_['tool']) && $_['tool']) { ?>
-        <?php foreach($_['tool'] as $tool) {  ?>
-            <li><?php echo $tool; ?></li>
-        <?php }} ?>
+
+        <?php foreach($_['tool'] as $tools) {  ?>
+            <li><?php echo $tools; ?></li>
+        <?php } ?>
     </ul>
     <ul>
         <h3><?php p($l->t('Ingredients')); ?></h3>
-        <?php if(isset($_['recipeIngredient']) && $_['recipeIngredient']) { ?>
+
         <?php foreach($_['recipeIngredient'] as $ingredient) {  ?>
             <li><?php echo $ingredient; ?></li>   
-        <?php }} ?>
+        <?php } ?>
     </ul>    
 </aside>
 
 <main>
     <ol>
         <h3><?php p($l->t('Instructions')); ?></h3>
-        <?php if(isset($_['recipeInstructions']) && $_['recipeInstructions']) { ?>
+
         <?php foreach($_['recipeInstructions'] as $step) {  ?>
             <li><?php echo nl2br($step); ?></li>   
-        <?php }} ?>
+        <?php } ?>
     </ol>
 </main>
 

--- a/templates/content/recipe.php
+++ b/templates/content/recipe.php
@@ -49,27 +49,27 @@
 <aside>
     <ul>
         <h3><?php p($l->t('Tools')); ?></h3>
-
-        <?php foreach($_['tool'] as $tools) {  ?>
-            <li><?php echo $tools; ?></li>
-        <?php } ?>
+        <?php if(isset($_['tool']) && $_['tool']) { ?>
+        <?php foreach($_['tool'] as $tool) {  ?>
+            <li><?php echo $tool; ?></li>
+        <?php }} ?>
     </ul>
     <ul>
         <h3><?php p($l->t('Ingredients')); ?></h3>
-
+        <?php if(isset($_['recipeIngredient']) && $_['recipeIngredient']) { ?>
         <?php foreach($_['recipeIngredient'] as $ingredient) {  ?>
             <li><?php echo $ingredient; ?></li>   
-        <?php } ?>
+        <?php }} ?>
     </ul>    
 </aside>
 
 <main>
     <ol>
         <h3><?php p($l->t('Instructions')); ?></h3>
-
+        <?php if(isset($_['recipeInstructions']) && $_['recipeInstructions']) { ?>
         <?php foreach($_['recipeInstructions'] as $step) {  ?>
             <li><?php echo nl2br($step); ?></li>   
-        <?php } ?>
+        <?php }} ?>
     </ol>
 </main>
 


### PR DESCRIPTION
When adding the new schema word `tool` i forgot to implement the standardization for this keyword. This resulted in jsons that had no `too` key, if no tool was specified. Although this didn't result in errors for me it did for at least one user #118 . The `foreach` function seems in some php? versions be able to iterate over non existing variables (basically just ignore them). Some setups throw an error because the non existing variable is not an array.

I'm opening a pull request because i made changes to exisiting code which i'm unsure if they are correct. See in the comments.
