### PR TITLE
Hide zero times

### DIFF
--- a/templates/content/recipe.php
+++ b/templates/content/recipe.php
@@ -50,36 +50,39 @@
 				$prep_interval = new DateInterval($_['prepTime']);
 				$prep_mins = $prep_interval->format('%I');
 				$prep_hours = $prep_interval->format('%h');
+                if ($prep_hours > 0 || $prep_mins > 0) {
 			?>
 				<div class="time" data-raw="<?php echo $_['prepTime']; ?>">
 		            <h4><?php p($l->t('Preparation time')); ?></h4>
 					<p><?php echo $prep_hours . ':' . $prep_mins; ?></p>
 				</div>
-	        <?php } ?>
+            <?php }} ?>
 
 			<?php if(isset($_['cookTime']) && $_['cookTime']) {
 				$cook_interval = new DateInterval($_['cookTime']);
 				$cook_mins = $cook_interval->format('%I');
 				$cook_hours = $cook_interval->format('%h');
+                if ($cook_hours > 0 || $cook_mins > 0) {
 			?>
                 <div class="time" data-raw="<?php echo $_['cookTime']; ?>">
 					<button type="button" class="icon-play" data-hours="<?php echo $cook_hours ?>" data-minutes="<?php echo $cook_mins ?>"></button>
 		            <h4><?php p($l->t('Cooking time')); ?></h4>
 					<p><?php echo $cook_hours . ':' . $cook_mins; ?></p>
 				</div>
-	        <?php } ?>
+            <?php }} ?>
 			
 			<?php
 			if(isset($_['totalTime']) && $_['totalTime']) {
 				$total_interval = new DateInterval($_['totalTime']);
 				$total_mins = $total_interval->format('%I');
 				$total_hours = $total_interval->format('%h');
+                if ($total_hours > 0 || $total_mins > 0) {
 			?>
 				<div class="time" data-raw="<?php echo $_['totalTime']; ?>">
 		            <h4><?php p($l->t('Total time')); ?></h4>
 					<p><?php echo $total_hours . ':' . $total_mins; ?></p>
 				</div>
-	        <?php } ?>
+            <?php }} ?>
 		</div>
     </div>
 </header>


### PR DESCRIPTION
When importing and editing recipes, if you end up with 0 values for
the cook or prep times, the recipe page will show big boxes displaying
unhelpful 0 values.  This commit omits those boxes as needed.

I offer this code under the terms of the AGPLv3 or any later version.