### PR TITLE
Make browser cache recipe images until changed

### DIFF
--- a/lib/Controller/MainController.php
+++ b/lib/Controller/MainController.php
@@ -66,6 +66,22 @@ class MainController extends Controller
         return new DataResponse($keywords, 200, ['Content-Type' => 'application/json']);
     }
 
+    public function imageModificationTime($id, $size)
+    {
+        $path_candidates = [
+            $this->service->getRecipeImageFileByFolderId($id, $size),
+            dirname(__FILE__) . '/../../img/recipe-' . $size . '.jpg'
+        ];
+
+        foreach($path_candidates as $path) {
+            if(file_exists($path)) {
+                return filemtime($path);
+            }
+        }
+
+        return -1;
+    }
+
     /**
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -76,7 +92,8 @@ class MainController extends Controller
 			$recipes = $this->service->getAllRecipesInSearchIndex();
 			
 			foreach ($recipes as $i => $recipe) {
-				$recipes[$i]['image_url'] = $this->urlGenerator->linkToRoute('cookbook.recipe.image', ['id' => $recipe['recipe_id'], 'size' => 'thumb']);
+				$mtime = $this->imageModificationTime($recipe['recipe_id'], 'thumb');
+				$recipes[$i]['image_url'] = $this->urlGenerator->linkToRoute('cookbook.recipe.image', ['id' => $recipe['recipe_id'], 'size' => 'thumb', 't' => $mtime]);
 			}
 			
 			$response = new TemplateResponse($this->appName, 'content/search', ['recipes' => $recipes]);
@@ -111,7 +128,8 @@ class MainController extends Controller
 			$recipes = $this->service->findRecipesInSearchIndex($query);
 			
 			foreach ($recipes as $i => $recipe) {
-				$recipes[$i]['image_url'] = $this->urlGenerator->linkToRoute('cookbook.recipe.image', ['id' => $recipe['recipe_id'], 'size' => 'thumb']);
+				$mtime = $this->imageModificationTime($recipe['recipe_id'], 'thumb');
+				$recipes[$i]['image_url'] = $this->urlGenerator->linkToRoute('cookbook.recipe.image', ['id' => $recipe['recipe_id'], 'size' => 'thumb', 't' => $mtime]);
 			}
 			
 			$response = new TemplateResponse($this->appName, 'content/search', ['query' => $query, 'recipes' => $recipes]);
@@ -135,7 +153,8 @@ class MainController extends Controller
 			$recipes = $this->service->getRecipesByCategory($category);
 			
 			foreach ($recipes as $i => $recipe) {
-				$recipes[$i]['image_url'] = $this->urlGenerator->linkToRoute('cookbook.recipe.image', ['id' => $recipe['recipe_id'], 'size' => 'thumb']);
+				$mtime = $this->imageModificationTime($recipe['recipe_id'], 'thumb');
+				$recipes[$i]['image_url'] = $this->urlGenerator->linkToRoute('cookbook.recipe.image', ['id' => $recipe['recipe_id'], 'size' => 'thumb', 't' => $mtime]);
 			}
 			
 			$response = new TemplateResponse($this->appName, 'content/search', ['tag' => $tag, 'recipes' => $recipes]);
@@ -155,7 +174,8 @@ class MainController extends Controller
     {
         try {
             $recipe = $this->service->getRecipeById($id);
-            $recipe['imageURL'] = $this->urlGenerator->linkToRoute('cookbook.recipe.image', ['id' => $id, 'size' => 'full']);
+            $mtime = $this->imageModificationTime($id, 'full');
+            $recipe['imageURL'] = $this->urlGenerator->linkToRoute('cookbook.recipe.image', ['id' => $id, 'size' => 'full', 't' => $mtime]);
             $recipe['id'] = $id;
             $response = new TemplateResponse($this->appName, 'content/recipe', $recipe);
             $response->renderAs('blank');


### PR DESCRIPTION
I noticed that my browser reloads all the thumbnails everytime when the home page of the Cookbook app is loaded. After some investigation I found out, that a dynamic `t=TIMESTAMP` parameter is added to each image URL. I guess this is to explicitly prevent the browser from caching the images which would be a problem when the user changes a recipe image.

This PR implements a PoC for setting the `t=` parameter not to the request time but to the modification time of the requested image as well as the header `Cache-Control: public, max-age=604800`. This way, the browser will be able to cache all images but still reloads them when the user changes the recipe image.

Please bear with me concerning the implementation. I usually don't write PHP code and couldn't figure out where the appropriate place for the `imageModificationTime()` function would be. In order to produce a working PoC, I simply duplicated the function which is really bad practice I admit. Feel free to shuffle around my code as you desire :)

And btw: thank you for this awesome Nextcloud app :upside_down_face: 