### PR TITLE
Improve input groups and use one for update interval setting hint

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@
     <screenshot small-thumbnail="https://raw.githubusercontent.com/mrzapp/nextcloud-cookbook/stable/img/screenshot-small.jpg">https://raw.githubusercontent.com/mrzapp/nextcloud-cookbook/stable/img/screenshot.jpg</screenshot>
     <bugs>https://github.com/mrzapp/nextcloud-cookbook/issues</bugs>
     <dependencies>
-        <nextcloud min-version="14" max-version="18"/>
+        <nextcloud min-version="14" max-version="19"/>
     </dependencies>
     <navigations>
         <navigation>

--- a/css/style.css
+++ b/css/style.css
@@ -3,12 +3,11 @@
  */
 
 .icon-arrow-up {
-    background-image: var(--icon-download-000);
-    transform: rotate(180deg);
+    background-image: var(--icon-triangle-n-000);
 }
 
 .icon-arrow-down {
-    background-image: var(--icon-download-000);
+    background-image: var(--icon-triangle-s-000);
 }
 
 .input-group {
@@ -16,35 +15,67 @@
     width: 100%;
 }
 
-.input-group > input {
-    width: 100%;
-    margin: 0;
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-}
+    .input-group > input {
+        width: 100%;
+        margin: 0;
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+    }
 
+    .input-group > .input-group-addon {
+        display: flex;
+    }
 
-.input-group > .input-group-addon {
-    display: flex;
-}
+        .input-group > .input-group-addon > button {
+            padding: 0;
+            margin: 0;
+            min-width: 34px;
+            min-height: 34px;
+        }
 
-.input-group > .input-group-addon > button {
-    padding: 0;
-    margin: 0;
-    min-width: 34px;
-}
+        .input-group > .input-group-addon > button {
+            border-radius: 0;
+            border-left-color: transparent;
+            border-right-color: transparent;
+        }
 
-.input-group > .input-group-addon > button {
-    border-radius: 0;
-    border-left-color: transparent;
-    border-right-color: transparent;
-}
+        .input-group > .input-group-addon > button:last-child {
+            border-top-right-radius: var(--border-radius);
+            border-bottom-right-radius: var(--border-radius);
+            border-right-width: 1px;
+        }
 
-.input-group > .input-group-addon > button:last-child {
-    border-top-right-radius: var(--border-radius);
-    border-bottom-right-radius: var(--border-radius);
-    border-right-width: 1px;
+.textarea-group {
+    
 }
+    .textarea-group-addon {
+        float: right;
+        display: flex;
+        position: relative;
+        top: 1px;
+        z-index: 1;
+    }
+        
+        .textarea-group-addon::after {
+            display: table;
+            content: '';
+            clear: both;
+        }
+        
+        .textarea-group-addon button {
+            min-width: 34px;
+            min-height: 34px;
+            border-radius: 0;
+            margin: 0;
+        }
+        
+        .textarea-group-addon button:first-child {
+            border-top-left-radius: var(--border-radius);
+        }
+        
+        .textarea-group-addon button:last-child {
+            border-top-right-radius: var(--border-radius);
+        }
 
 /**
  * Main
@@ -452,8 +483,6 @@
         }
         
         #app-content-wrapper form fieldset > ul > li {
-            display: flex;
-            width: 100%;
             margin: 0 0 1em 0;
         }
 
@@ -480,6 +509,11 @@
             width: 100%;
             margin: 0;
             border-top-right-radius: 0;
+        }
+
+        #app-content-wrapper form fieldset > ul > li .step-number {
+            padding: 6px;
+            float: left;
         }
 
         #app-content-wrapper form button[type="submit"] {

--- a/css/style.css
+++ b/css/style.css
@@ -1,4 +1,52 @@
 /**
+ * Helpers
+ */
+
+.icon-arrow-up {
+    background-image: var(--icon-download-000);
+    transform: rotate(180deg);
+}
+
+.icon-arrow-down {
+    background-image: var(--icon-download-000);
+}
+
+.input-group {
+    display: flex;
+    width: 100%;
+}
+
+.input-group > input {
+    width: 100%;
+    margin: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+
+.input-group > .input-group-addon {
+    display: flex;
+}
+
+.input-group > .input-group-addon > button {
+    padding: 0;
+    margin: 0;
+    min-width: 34px;
+}
+
+.input-group > .input-group-addon > button {
+    border-radius: 0;
+    border-left-color: transparent;
+    border-right-color: transparent;
+}
+
+.input-group > .input-group-addon > button:last-child {
+    border-top-right-radius: var(--border-radius);
+    border-bottom-right-radius: var(--border-radius);
+    border-right-width: 1px;
+}
+
+/**
  * Main
  */
 #app {
@@ -414,39 +462,6 @@
             margin: 0;
             border-top-right-radius: 0;
             border-bottom-right-radius: 0;
-        }
-
-        #app-content-wrapper form fieldset > ul > li > .list-item-tools {
-            display: flex;
-        }
-        
-        #app-content-wrapper form fieldset > ul > li > .list-item-tools > button {
-            padding: 0;
-            margin: 0;
-            flex-basis: 34px;
-            min-width: 34px;
-            max-height: 34px;
-        }
-        
-        #app-content-wrapper form fieldset > ul > li > .list-item-tools > button {
-            border-radius: 0;
-            border-left-width: 0;
-            border-right-width: 0;
-        }
-        
-        #app-content-wrapper form fieldset > ul > li > .list-item-tools > button:last-child {
-            border-top-right-radius: var(--border-radius);
-            border-bottom-right-radius: var(--border-radius);
-            border-right-width: 1px;
-        }
-        
-        #app-content-wrapper form fieldset > ul > li > .list-item-tools .icon-arrow-up {
-            background-image: var(--icon-download-000);
-            transform: rotate(180deg);
-        }
-        
-        #app-content-wrapper form fieldset > ul > li > .list-item-tools .icon-arrow-down {
-            background-image: var(--icon-download-000);
         }
 
         #app-content-wrapper form fieldset > ul > li > button {

--- a/js/script.js
+++ b/js/script.js
@@ -394,17 +394,35 @@ var Content = function (cookbook) {
      * Updates all lists items with click events
      */
     self.updateListItems = function(e) {
-        $('#app-content-wrapper form .remove-list-item').off('click');
-        $('#app-content-wrapper form .remove-list-item').click(self.onDeleteListItem);
+        $('#app-content-wrapper form .remove-list-item')
+            .off('click')
+            .click(self.onDeleteListItem);
         
-        $('#app-content-wrapper form .move-list-item-up').off('click');
-        $('#app-content-wrapper form .move-list-item-up').click(self.onMoveListItemUp);
+        $('#app-content-wrapper form .move-list-item-up')
+            .off('click')
+            .click(self.onMoveListItemUp)
+            .prop('disabled', false);
         
-        $('#app-content-wrapper form .move-list-item-down').off('click');
-        $('#app-content-wrapper form .move-list-item-down').click(self.onMoveListItemDown);
+        $('#app-content-wrapper form li:first-of-type .move-list-item-up').prop('disabled', true);
+        
+        $('#app-content-wrapper form .move-list-item-down')
+            .off('click')
+            .click(self.onMoveListItemDown)
+            .prop('disabled', false);
+        
+        $('#app-content-wrapper form li:last-of-type .move-list-item-down').prop('disabled', true);
 
-        $('#app-content-wrapper form ul li input[type="text"]').off('keypress');
-        $('#app-content-wrapper form ul li input[type="text"]').on('keypress', self.onListInputKeyDown);
+        $('#app-content-wrapper form ul li input[type="text"]')
+            .off('keypress')
+            .on('keypress', self.onListInputKeyDown);
+        
+        console.log('order');
+        $('#app-content-wrapper form ul').each(function() {
+            var stepNumber = 1;
+            $(this).find('.step-number').each(function() {
+                $(this).text(stepNumber++ + '.');
+            });
+        });
     }
 
     /**
@@ -419,6 +437,8 @@ var Content = function (cookbook) {
         var list = listItem.parentElement;
 
         list.removeChild(listItem);
+        
+        self.updateListItems();
     };
 
     /**
@@ -454,7 +474,7 @@ var Content = function (cookbook) {
         $ul.append($item);
 
         $item.find('input').focus();
-
+        
         self.updateListItems();
     };
     
@@ -473,6 +493,8 @@ var Content = function (cookbook) {
         }
 
         $(listItem).insertBefore($(listItem.previousElementSibling));
+        
+        self.updateListItems();
     };
     
     /**
@@ -490,6 +512,8 @@ var Content = function (cookbook) {
         }
 
         $(listItem).insertAfter($(listItem.nextElementSibling));
+        
+        self.updateListItems();
     };
 
     /**

--- a/js/script.js
+++ b/js/script.js
@@ -242,6 +242,9 @@ var Content = function (cookbook) {
 			$('#app-content-wrapper form ul li input[type="text"]').off('keypress');
 			$('#app-content-wrapper form ul li input[type="text"]').on('keypress', self.onListInputKeyDown);
 			
+			$('#app-settings [title]').tooltip('destroy');
+			$('#app-settings [title]').tooltip();
+			
             self.updateListItems();
 			
             // View

--- a/templates/content/edit.php
+++ b/templates/content/edit.php
@@ -149,24 +149,26 @@
             <label><?php p($l->t('Instructions')); ?></label>
             <ul>
                 <template>
-                    <li class="input-group">
-                        <textarea name="recipeInstructions[]"></textarea>
-                        <div class="input-group-addon">
+                    <li class="textarea-group">
+                        <div class="step-number"></div>
+                        <div class="textarea-group-addon">
                             <button class="icon-arrow-up move-list-item-up"></button>
                             <button class="icon-arrow-down move-list-item-down"></button>
                             <button class="icon-delete right remove-list-item"></button>
                         </div>
+                        <textarea name="recipeInstructions[]"></textarea>
                     </li>
                 </template>
                 <?php if(isset($_['recipeInstructions']) && is_array($_['recipeInstructions'])) { ?>
                     <?php foreach ($_['recipeInstructions'] as $i => $step) { ?>
-                        <li class="input-group">
-                            <textarea name="recipeInstructions[]"><?php echo $step; ?></textarea>
-                            <div class="input-group-addon">
+                        <li class="textarea-group">
+                            <div class="step-number"><?php echo ($i + 1); ?>.</div>
+                            <div class="textarea-group-addon">
                                 <button class="icon-arrow-up move-list-item-up"></button>
                                 <button class="icon-arrow-down move-list-item-down"></button>
                                 <button class="icon-delete right remove-list-item"></button>
                             </div>
+                            <textarea name="recipeInstructions[]"><?php echo $step; ?></textarea>
                         </li>
                     <?php } ?>
                 <?php } ?>

--- a/templates/content/edit.php
+++ b/templates/content/edit.php
@@ -91,9 +91,9 @@
             <label><?php p($l->t('Tools')); ?></label>
             <ul>
                 <template>
-                    <li>
+                    <li class="input-group">
                         <input type="text" name="tool[]" value="">
-                        <div class="list-item-tools">
+                        <div class="input-group-addon">
                             <button class="icon-arrow-up move-list-item-up"></button>
                             <button class="icon-arrow-down move-list-item-down"></button>
                             <button class="icon-delete right remove-list-item"></button>
@@ -102,9 +102,9 @@
                 </template>
                 <?php if(isset($_['tool']) && is_array($_['tool'])) { ?>
                     <?php foreach ($_['tool'] as $i => $tool) { ?>
-                        <li>
+                        <li class="input-group">
                             <input type="text" name="tool[]" value="<?php echo $tool; ?>">
-                            <div class="list-item-tools">
+                            <div class="input-group-addon">
                                 <button class="icon-arrow-up move-list-item-up"></button>
                                 <button class="icon-arrow-down move-list-item-down"></button>
                                 <button class="icon-delete right remove-list-item"></button>
@@ -120,9 +120,9 @@
             <label><?php p($l->t('Ingredients')); ?></label>
             <ul>
                 <template>
-                    <li>
+                    <li class="input-group">
                         <input type="text" name="recipeIngredient[]" value="">
-                        <div class="list-item-tools">
+                        <div class="input-group-addon">
                             <button class="icon-arrow-up move-list-item-up"></button>
                             <button class="icon-arrow-down move-list-item-down"></button>
                             <button class="icon-delete right remove-list-item"></button>
@@ -131,9 +131,9 @@
                 </template>
                 <?php if(isset($_['recipeIngredient']) && is_array($_['recipeIngredient'])) { ?>
                     <?php foreach ($_['recipeIngredient'] as $i => $ingredient) { ?>
-                        <li>
+                        <li class="input-group">
                             <input type="text" name="recipeIngredient[]" value="<?php echo $ingredient; ?>">
-                            <div class="list-item-tools">
+                            <div class="input-group-addon">
                                 <button class="icon-arrow-up move-list-item-up"></button>
                                 <button class="icon-arrow-down move-list-item-down"></button>
                                 <button class="icon-delete right remove-list-item"></button>
@@ -149,9 +149,9 @@
             <label><?php p($l->t('Instructions')); ?></label>
             <ul>
                 <template>
-                    <li>
+                    <li class="input-group">
                         <textarea name="recipeInstructions[]"></textarea>
-                        <div class="list-item-tools">
+                        <div class="input-group-addon">
                             <button class="icon-arrow-up move-list-item-up"></button>
                             <button class="icon-arrow-down move-list-item-down"></button>
                             <button class="icon-delete right remove-list-item"></button>
@@ -160,9 +160,9 @@
                 </template>
                 <?php if(isset($_['recipeInstructions']) && is_array($_['recipeInstructions'])) { ?>
                     <?php foreach ($_['recipeInstructions'] as $i => $step) { ?>
-                        <li>
+                        <li class="input-group">
                             <textarea name="recipeInstructions[]"><?php echo $step; ?></textarea>
-                            <div class="list-item-tools">
+                            <div class="input-group-addon">
                                 <button class="icon-arrow-up move-list-item-up"></button>
                                 <button class="icon-arrow-down move-list-item-down"></button>
                                 <button class="icon-delete right remove-list-item"></button>

--- a/templates/settings/index.php
+++ b/templates/settings/index.php
@@ -19,7 +19,7 @@
                     <div class="input-group">
                         <input id="recipe-update-interval" type="number" class="input settings-input" value="<?php echo $_['update_interval']; ?>" placeholder="<?php echo $_['update_interval']; ?>">
                         <div class="input-group-addon">
-                            <button class="icon-info" disabled="disabled" title="<?php p($l->t('Last update')); ?>: <?php echo date('Y-m-d H:i', $_['last_update']); ?>"></button>
+                            <button class="icon-info" disabled="disabled" title="<?php p($l->t('Last update:')); ?> <?php echo date('Y-m-d H:i', $_['last_update']); ?>"></button>
                         </div>
                     </div>
                 </li>

--- a/templates/settings/index.php
+++ b/templates/settings/index.php
@@ -15,10 +15,13 @@
                 <li class="settings-fieldset-interior-item">
                     <label class="settings-input">
                         <?php p($l->t('Update interval in minutes')); ?>
-                        <br>
-                        (<?php p($l->t('Last update')); ?>: <?php echo date('Y-m-d H:i', $_['last_update']); ?>)
                     </label>
-                    <input id="recipe-update-interval" type="number" class="input settings-input" value="<?php echo $_['update_interval']; ?>" placeholder="<?php echo $_['update_interval']; ?>">
+                    <div class="input-group">
+                        <input id="recipe-update-interval" type="number" class="input settings-input" value="<?php echo $_['update_interval']; ?>" placeholder="<?php echo $_['update_interval']; ?>">
+                        <div class="input-group-addon">
+                            <button class="icon-info" disabled="disabled" title="<?php p($l->t('Last update')); ?>: <?php echo date('Y-m-d H:i', $_['last_update']); ?>"></button>
+                        </div>
+                    </div>
                 </li>
             </ul>
         </fieldset>


### PR DESCRIPTION
In order to add more settings for #161, I wanted to improve the look of current settings, so I used a tooltip to display the last update time.

![image](https://user-images.githubusercontent.com/6164603/79069616-ec22ce80-7ccf-11ea-8ead-acc7f4d39622.png)

And to do that, I created a shared `.input-group` class with an `.input-group-addon`, (based on bootstrap3 vocabulary) and replaced the current `.list-item-tools`.

I also removed the `max-height` on buttons in this case, so that they fit textarea height, which looks better IMO (see screenshot below). But I guess that's not for me to decide ultimately :)
Also, I fixed button borders on hover.

![image](https://user-images.githubusercontent.com/6164603/79069600-c5fd2e80-7ccf-11ea-9d3f-8c9a51da9f0a.png)

Looking forward to your comments!