### PR TITLE
appinfo: add link to the website

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,6 +10,7 @@
     <author mail="mrzapp@users.noreply.github.com" >Jeppe Zapp</author>
     <namespace>Cookbook</namespace>
     <category>organization</category>
+    <website>https://github.com/mrzapp/nextcloud-cookbook/</website>
     <screenshot small-thumbnail="https://raw.githubusercontent.com/mrzapp/nextcloud-cookbook/stable/img/screenshot-small.jpg">https://raw.githubusercontent.com/mrzapp/nextcloud-cookbook/stable/img/screenshot.jpg</screenshot>
     <bugs>https://github.com/mrzapp/nextcloud-cookbook/issues</bugs>
     <dependencies>


### PR DESCRIPTION
First: thank you for this useful Nextcloud app!

This is a detail but it is useful to get a link to this repo, e.g. to
check the ChangeLog (last commits), the code, etc.

We can see this link from https://apps.nextcloud.com/apps/cookbook
but also in Netcloud settings.