### PR TITLE
Reload recipes after rescan

### DIFF
--- a/src/components/AppNavi.vue
+++ b/src/components/AppNavi.vue
@@ -287,6 +287,10 @@ export default {
                 $this.scanningLibrary = false
                 console.log("Library reindexing complete")
                 $this.getCategories()
+                if (['search', 'recipe', 'edit'].indexOf($this.$store.state.page) > -1) {
+                    // This refreshes the current router view in case items in it changed during reindex
+                    $this.$router.go()
+                }
             }).fail(function (jqXHR, textStatus, errorThrown) {
                 deferred.reject(new Error(jqXHR.responseText))
                 $this.scanningLibrary = false

--- a/src/components/AppNavi.vue
+++ b/src/components/AppNavi.vue
@@ -287,7 +287,7 @@ export default {
                 $this.scanningLibrary = false
                 console.log("Library reindexing complete")
                 $this.getCategories()
-                if (['search', 'recipe', 'edit'].indexOf($this.$store.state.page) > -1) {
+                if (['index', 'search'].indexOf($this.$store.state.page) > -1) {
                     // This refreshes the current router view in case items in it changed during reindex
                     $this.$router.go()
                 }

--- a/src/components/AppNavi.vue
+++ b/src/components/AppNavi.vue
@@ -193,6 +193,7 @@ export default {
             }).done(function (recipe) {
                 $this.downloading = false
                 $this.$window.goTo('/recipe/' + recipe.id)
+                e.target[1].value = ''
                 deferred.resolve()
             }).fail(function (jqXHR, textStatus, errorThrown) {
                 $this.downloading = false

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -105,8 +105,14 @@ export default {
                 $this.setup()
             }).fail(function(e) {
                 alert($this.t('Loading recipe failed'))
-                // Browse back to the previous page
-                $this.$window.gotTo(-1)
+                // Disable loading indicator
+                if ($this.$store.state.loadingRecipe) {
+                    $this.$store.dispatch('setLoadingRecipe', { recipe: 0 })
+                } else if ($this.$store.state.reloadingRecipe) {
+                    $this.$store.dispatch('setReloadingRecipe', { recipe: 0 })
+                }
+                // Browse to new recipe creation
+                $this.$window.goTo('/recipe/create')
             })
         },
         moveEntryDown: function(field, index) {


### PR DESCRIPTION
Resolves #168 and #183 (merge my other pull request first)

This performs just a crude refresh of the router view. For a more sophisticated solution (like only reloading the recipes and not the whole view, which would avoid the view flashing empty for a split second) some more fine-grained checking would be needed.