### PR TITLE
Avoid duplicate field key

### DIFF
--- a/src/components/AppNavi.vue
+++ b/src/components/AppNavi.vue
@@ -287,6 +287,10 @@ export default {
                 $this.scanningLibrary = false
                 console.log("Library reindexing complete")
                 $this.getCategories()
+                if (['search', 'recipe', 'edit'].indexOf($this.$store.state.page) > -1) {
+                    // This refreshes the current router view in case items in it changed during reindex
+                    $this.$router.go()
+                }
             }).fail(function (jqXHR, textStatus, errorThrown) {
                 deferred.reject(new Error(jqXHR.responseText))
                 $this.scanningLibrary = false

--- a/src/components/AppNavi.vue
+++ b/src/components/AppNavi.vue
@@ -287,7 +287,7 @@ export default {
                 $this.scanningLibrary = false
                 console.log("Library reindexing complete")
                 $this.getCategories()
-                if (['search', 'recipe', 'edit'].indexOf($this.$store.state.page) > -1) {
+                if (['index', 'search'].indexOf($this.$store.state.page) > -1) {
                     // This refreshes the current router view in case items in it changed during reindex
                     $this.$router.go()
                 }

--- a/src/components/AppNavi.vue
+++ b/src/components/AppNavi.vue
@@ -193,6 +193,7 @@ export default {
             }).done(function (recipe) {
                 $this.downloading = false
                 $this.$window.goTo('/recipe/' + recipe.id)
+                e.target[1].value = ''
                 deferred.resolve()
             }).fail(function (jqXHR, textStatus, errorThrown) {
                 $this.downloading = false

--- a/src/components/RecipeEdit.vue
+++ b/src/components/RecipeEdit.vue
@@ -105,8 +105,14 @@ export default {
                 $this.setup()
             }).fail(function(e) {
                 alert($this.t('Loading recipe failed'))
-                // Browse back to the previous page
-                $this.$window.gotTo(-1)
+                // Disable loading indicator
+                if ($this.$store.state.loadingRecipe) {
+                    $this.$store.dispatch('setLoadingRecipe', { recipe: 0 })
+                } else if ($this.$store.state.reloadingRecipe) {
+                    $this.$store.dispatch('setReloadingRecipe', { recipe: 0 })
+                }
+                // Browse to new recipe creation
+                $this.$window.goTo('/recipe/create')
             })
         },
         moveEntryDown: function(field, index) {

--- a/src/components/RecipeView.vue
+++ b/src/components/RecipeView.vue
@@ -24,21 +24,21 @@
                     <section>
                         <h3 v-if="ingredients.length">{{ t('Ingredients') }}</h3>
                         <ul v-if="ingredients.length">
-                            <RecipeIngredient v-for="ingredient in ingredients" :key="ingredient" :ingredient="ingredient" />
+                            <RecipeIngredient v-for="(ingredient,idx) in ingredients" :key="'ingr'+idx" :ingredient="ingredient" />
                         </ul>
                     </section>
 
                     <section>
                         <h3 v-if="tools.length">{{ t('Tools') }}</h3>
                         <ul v-if="tools.length">
-                            <RecipeTool v-for="tool in tools" :key="tool" :tool="tool" />
+                            <RecipeTool v-for="(tool,idx) in tools" :key="'tool'+idx" :tool="tool" />
                         </ul>
                     </section>
                 </aside>
                 <main v-if="instructions.length">
                     <h3>{{ t('Instructions') }}</h3>
                     <ol class="instructions">
-                        <RecipeInstruction v-for="instruction in instructions" :key="instruction" :instruction="instruction" />
+                        <RecipeInstruction v-for="(instruction,idx) in instructions" :key="'instr'+idx" :instruction="instruction" />
                     </ol>
                 </main>
             </section>


### PR DESCRIPTION
Simple fix to avoid possible duplicate field keys in recipe instructions, tools and instructions.

Includes fix for #168 and #183 