### PR TITLE
Word wrap description when necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ They probably haven't been indexed. Try clicking the Settings > Rescan library b
 A lot of websites are unfortunately not following the schema.org/Recipe standard, which makes their recipes impossible to read by this app.
 
 #### A website using correct schema.org markup is not being read correctly
-The parser is far from perfect. If you can help out in any way, please [have a look at the parseRecipeHtml() method](https://github.com/mrzapp/nextcloud-cookbook/blob/develop/lib/Service/RecipeService.php) and create a pull request with your changes.
+The parser is far from perfect. If you can help out in any way, please [have a look at the parseRecipeHtml() method](https://github.com/mrzapp/nextcloud-cookbook/blob/master/lib/Service/RecipeService.php) and create a pull request with your changes.
 
 #### All of the text is in English?
 This app uses the [Transifex](https://www.transifex.com/nextcloud/nextcloud/cookbook/) translation system.

--- a/src/components/RecipeView.vue
+++ b/src/components/RecipeView.vue
@@ -218,7 +218,7 @@ aside {
 
         .description {
             font-style: italic;
-            white-space: pre;
+            white-space: pre-line;
         }
         .details p {
             margin: 0.5em 0


### PR DESCRIPTION
I often view the recipes on my phone, and if the description is long it breaks the layout (everything else word wraps nicely).

I suggest pre-line here since it seems that's what you used for e.g. instructions, but maybe you think another wrapping is more sensible.

I could also have filed an issue report but it's fun to see if I manage to fix myself :) Seemed to work

Edit: And thanks a bunch for creating this app, loving it! In particular loading recipe from url is brilliant.