### PR TITLE
Fix when json object is an array

### DIFF
--- a/lib/Service/RecipeService.php
+++ b/lib/Service/RecipeService.php
@@ -448,7 +448,14 @@ class RecipeService
 
             // Check if json is an array for some reason
             if($json && isset($json[0])) {
-                $json = $json[0];
+                $i = -1;
+                foreach ($json as $element) {
+                    $i++;
+                    if ($element && isset($element['@type']) && $element['@type'] == 'Recipe') {
+                        break;
+                    }
+                }
+                $json = $json[$i];
             }
 
             if (!$json || !isset($json['@type']) || $json['@type'] !== 'Recipe') {

--- a/lib/Service/RecipeService.php
+++ b/lib/Service/RecipeService.php
@@ -448,14 +448,11 @@ class RecipeService
 
             // Check if json is an array for some reason
             if($json && isset($json[0])) {
-                $i = -1;
                 foreach ($json as $element) {
-                    $i++;
                     if ($element && isset($element['@type']) && $element['@type'] == 'Recipe') {
-                        break;
+                        return $this->checkRecipe($json);
                     }
                 }
-                $json = $json[$i];
             }
 
             if (!$json || !isset($json['@type']) || $json['@type'] !== 'Recipe') {


### PR DESCRIPTION
I found that on allrecipes.com the last element of the array is the actual recipe object.

This fix searches through all elements of the json object found, if it is an array. Previous solution was to just pick the first object, which in the particular case would get a BreadCrumb object. If no recipe object is found, the last element is selected (instead of first) which should have no impact as the next check will say that it (still) isn't a recipe object and continue the outside for loop.

I checked that this worked on my installation, running NextCloud 18. Still I'm new here so please verify before merging!